### PR TITLE
update regex to allow for multi-tenant controllers

### DIFF
--- a/scripts/Get-AppDAuth.ps1
+++ b/scripts/Get-AppDAuth.ps1
@@ -28,7 +28,7 @@ function Get-AppDAuth
     }
     Process
     {
-        if ($Username -notmatch '.+?@customer1$') #ends with @customer1
+        if ($Username -notmatch '.+?@[a-zA-Z0-9]+$') #ends with @someAccountName
         {
             $Username += '@customer1'
         }


### PR DESCRIPTION
I was trying to use this module today and I kept getting a 401 from my controller when trying to set it up. I took a look and noticed that the Get-AppDAuth function was appending  @customer1 to my username. I use multi-tenant controllers and need to specify @myAccountName in my username and not @customer1. I changed the regex so the function doesn't append customer1 if the supplied username has any account name specified. After I made this change, I was able to authenticate to my controller. I didn't write any additional tests, but the ones you already have for this function all passed.